### PR TITLE
Fix "too few arguments to function ‘DGifCloseFile’"

### DIFF
--- a/src/gif2swf.c
+++ b/src/gif2swf.c
@@ -468,7 +468,7 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id, int imgidx)
 
     free(pal);
     free(imagedata);
-    DGifCloseFile(gft);
+    DGifCloseFile(gft, D_GIF_SUCCEEDED);
 
     return t;
 }
@@ -541,7 +541,7 @@ int CheckInputFile(char *fname, char **realname)
             fprintf(stderr, "frame: %u, delay: %.3f sec\n", i + 1, getGifDelayTime(gft, i) / 100.0);
     }
 
-    DGifCloseFile(gft);
+    DGifCloseFile(gft, D_GIF_SUCCEEDED);
 
     return 0;
 }


### PR DESCRIPTION
API changed for DGifCloseFile:
http://sourceforge.net/p/giflib/code/ci/116179a7d4681dda9afcdd43b5fbfb391b44918b/tree/doc/gif_lib.xml?diff=8408b09b69e5ce836d01a29e05c626ffa55cffaa