### PR TITLE
Patch for CVE-2017-7698

### DIFF
--- a/lib/pdf/xpdf-changes.patch
+++ b/lib/pdf/xpdf-changes.patch
@@ -2562,3 +2562,18 @@
    void copyVector(CMapVectorEntry *dest, CMapVectorEntry *src);
    void addCodeSpace(CMapVectorEntry *vec, Guint start, Guint end,
  		    Guint nBytes);
+
+--- xpdf-3.02_fix/Gfx.cc	2017-05-08 01:51:09.380121226 -0700
++++ xpdf-3.02/Gfx.cc	2017-05-08 01:57:04.690898645 -0700
+@@ -3850,6 +3850,11 @@
+     out->endTransparencyGroup(state);
+   }
+ 
++  if (old_state != state) {
++      error(getPos(), "There's a form with uneven q and Q operations");
++      exit(-1);
++  }
++
+   // restore base matrix
+   for (i = 0; i < 6; ++i) {
+     baseMatrix[i] = oldBaseMatrix[i];


### PR DESCRIPTION
This patch fixes a Use After Free vulnerability in the xpdf code used by swftools.