### PR TITLE
don't silently exit on unknown sound format

### DIFF
--- a/src/swfextract.c
+++ b/src/swfextract.c
@@ -1124,7 +1124,8 @@ int handledefinesound(TAG*tag)
 	printf("Sound is ADPCM, format: %s samples/sec, %d bit, %s\n", rates[rate], bits, stereo?"stereo":"mono");
 	extension = "adpcm";
     } else {
-        return 0;
+	printf("Unknown sound format %d: %s samples/sec, %d bit, %s\n", format, rates[rate], bits, stereo?"stereo":"mono");
+	extension = "unknown";
     }
     prepare_name(buf, sizeof(buf), "sound", extension, id);
     if(numextracts==1) {


### PR DESCRIPTION
With this patch it is possible to extract a sound with an unknown format number, rather than silently exiting which is unhelpful behaviour.