### PR TITLE
swfbits must be continue processing even if zlib infrate of image fails.

### DIFF
--- a/lib/modules/swfbits.c
+++ b/lib/modules/swfbits.c
@@ -645,7 +645,6 @@ RGBA *swf_JPEG2TagToImage(TAG * tag, int *width, int *height)
 	error = uncompress(alphadata, &datalen, &tag->data[tag->pos], tag->len - tag->pos);
 	if (error != Z_OK) {
 	    fprintf(stderr, "rfxswf: Zlib error %d while extracting definejpeg3\n", error);
-	    return 0;
 	}
 	for(y=0;y<cinfo.output_height;y++) {
 	    RGBA*line = &dest[y*cinfo.output_width];
@@ -989,7 +988,6 @@ RGBA *swf_DefineLosslessBitsTagToImage(TAG * tag, int *dwidth, int *dheight)
     } while (error == Z_BUF_ERROR);
     if (error != Z_OK) {
 	fprintf(stderr, "rfxswf: Zlib error %d (image %d)\n", error, id);
-	return 0;
     }
     pos = 0;
 


### PR DESCRIPTION
Solution suggestions for CVE-2017-16711
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16711

ref) https://github.com/matthiaskramm/swftools/issues/46

# background

   - swftools/lib/modules/swfbits.c

swf_DefineLosslessBitsTagToImage extract zlib compressed imagedata(RGBA)
swf_JPEG2TagToImage extracts zlib compressed alphadata(A) from JPEG3 tag.

# current

If these functions fail to inflate a zlib compressed RGBA(or A) array, return NULL as an RGBA array.
and users of the RGBA array reference it without NULL checking, causing a segmentation fault.

# solution

swfbits must be continue processing even if zlib infrate of image fails.

# TODO

CVE-2017-16711 will be superficially resolved.

If we want to be more secure, we need to add a NULL check to the code that references the RGBA array pointer. We should discuss this in a separate issue.