### PR TITLE
change rfx_alloc to rfx_calloc for Lossless RGBA, JPEG3 alpha zlib inflation buffer.

### DIFF
--- a/lib/modules/swfbits.c
+++ b/lib/modules/swfbits.c
@@ -638,7 +638,7 @@ RGBA *swf_JPEG2TagToImage(TAG * tag, int *width, int *height)
 #ifdef HAVE_ZLIB
     if(offset) {
 	uLongf datalen = cinfo.output_width*cinfo.output_height;
-	U8* alphadata = (U8*)rfx_alloc(datalen);
+	U8* alphadata = (U8*)rfx_calloc(datalen);
 	int error;
 	tag->len = oldtaglen;
 	swf_SetTagPos(tag, 6+offset);
@@ -981,7 +981,7 @@ RGBA *swf_DefineLosslessBitsTagToImage(TAG * tag, int *dwidth, int *dheight)
 	if (data)
 	    rfx_free(data);
 	datalen += 4096;
-	data = (U8*)rfx_alloc(datalen);
+	data = (U8*)rfx_calloc(datalen);
 	error =
 	    uncompress(data, &datalen, &tag->data[tag->pos],
 		       tag->len - tag->pos);


### PR DESCRIPTION
#46 was not enough care. I will fix it additionally.

For #46, the behavior has been changed so that processing continues even if inflation is incomplete.
With rfx_alloc(malloc wrapper),  the possibility of displaying uninitialized data remains.
Should be changed to rfx_calloc(calloc wrapper).