### PR TITLE
undef boolean/FALSE/TRUE in config.h.in for configure rules.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -19,6 +19,15 @@
 #undef SIZEOF_SIGNED_LONG_LONG
 #undef SIZEOF_VOIDP
 
+/* Define to `int' if <sys/types.h> does not define. */
+#undef boolean
+
+/* boolean constant false */
+#undef FALSE
+
+/* boolean constant true */
+#undef TRUE
+
 /* Define if you have the ANSI C header files.  */
 #undef STDC_HEADERS
 


### PR DESCRIPTION
In config.h.in, undef boolean/FALSE/TRUE for configure rules.
This is additional PR.
ref)  https://github.com/matthiaskramm/swftools/pull/67

I committed with this.
```
/* Define to `int' if <sys/types.h> does not define. */
#undef boolean

/* boolean constant false */
#undef FALSE

/* boolean constant true */
#undef TRUE
```

Looking at the surrounding code, the following may be better.

```
/* Define to `int' if <sys/types.h> does not define. */
#undef boolean

#undef FALSE
#undef TRUE
```