### PR TITLE
Avoid div 0 of src->align as denominator in samplelen calculation.

### DIFF
--- a/lib/wav.c
+++ b/lib/wav.c
@@ -212,6 +212,11 @@ int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
     int i;
     int fill;
 
+    if (src->align != (channels*bps/8)) {
+	fprintf(stderr, "Unsupported non-PCM convert to mono: align:%d != (channels:%d*bps:%d/8)\n", src->align , channels, bps);
+	return 0;
+    }
+
     dest->sampsPerSec = rate;
     dest->bps = 16;
     dest->channels = 1;

--- a/lib/wav.c
+++ b/lib/wav.c
@@ -291,6 +291,9 @@ int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
 	}
     } else {
 	fprintf(stderr, "Unsupported bitspersample value: %d\n", bps);
+	free(dest->data);
+	dest->data = 0;
+	return 0;
     }
     return 1;
 }

--- a/lib/wav.c
+++ b/lib/wav.c
@@ -203,7 +203,7 @@ void wav_print(struct WAV*wav)
 
 int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
 {
-    int samplelen=(src->size+(src->align-1))/src->align; // round up
+    int samplelen;
     int bps=src->bps;
     double ratio;
     double pos = 0;
@@ -212,6 +212,10 @@ int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
     int i;
     int fill;
 
+    if (src->align == 0) {
+	fprintf(stderr, "Illegal wave align == 0\n");
+	return 0;
+    }
     if (src->align != (channels*bps/8)) {
 	fprintf(stderr, "Unsupported non-PCM convert to mono: align:%d != (channels:%d*bps:%d/8)\n", src->align , channels, bps);
 	return 0;
@@ -224,6 +228,7 @@ int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
     dest->tag = src->tag;
     dest->bytesPerSec = dest->sampsPerSec*dest->align;
 
+    samplelen=(src->size+(src->align-1))/src->align; // round up
     ratio = (double)dest->sampsPerSec/(double)src->sampsPerSec;
     fill = (int)(ratio+1)*2;
     

--- a/lib/wav.c
+++ b/lib/wav.c
@@ -203,7 +203,7 @@ void wav_print(struct WAV*wav)
 
 int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
 {
-    int samplelen=src->size/src->align;
+    int samplelen=(src->size+(src->align-1))/src->align; // round up
     int bps=src->bps;
     double ratio;
     double pos = 0;

--- a/src/swfc.c
+++ b/src/swfc.c
@@ -1667,11 +1667,17 @@ void s_sound(const char*name, const char*filename)
 
     if(wav_read(&wav, filename))
     {
-        int t;
-        wav_convert2mono(&wav, &wav2, 44100);
-        samples = (U16*)wav2.data;
-        numsamples = wav2.size/2;
-        free(wav.data);
+	int t;
+	if(!wav_convert2mono(&wav, &wav2, 44100))
+	{
+	    warning("Couldn't convert WAV file \"%s\" to mono", filename);
+	    samples = 0;
+	    numsamples = 0;
+	} else {
+	    samples = (U16*)wav2.data;
+	    numsamples = wav2.size/2;
+	}
+	free(wav.data);
 #ifdef WORDS_BIGENDIAN
 	/* swap bytes */
         for(t=0;t<numsamples;t++)

--- a/src/wav2swf.c
+++ b/src/wav2swf.c
@@ -232,7 +232,12 @@ int main (int argc,char ** argv)
 	msg("<fatal> Error reading %s", filename);
 	exit(1);
     }
-    wav_convert2mono(&wav,&wav2, samplerate);
+
+    if(!wav_convert2mono(&wav, &wav2, samplerate))
+    {
+	msg("<fatal> Error convert %s to mono", filename);
+	exit(1);
+    }
     //wav_print(&wav);
     //wav_print(&wav2);
     samples = (U16*)wav2.data;


### PR DESCRIPTION
Checking src->align non-zero
Avoid div 0 of align as denominator in samplelen calculation.

ref) https://github.com/matthiaskramm/swftools/issues/57