### PR TITLE
Avoid div 0 of src->align as denominator in samplelen calculation. 

### DIFF
--- a/lib/wav.c
+++ b/lib/wav.c
@@ -203,7 +203,7 @@ void wav_print(struct WAV*wav)
 
 int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
 {
-    int samplelen=(src->size+(src->align-1))/src->align; // round up
+    int samplelen;
     int bps=src->bps;
     double ratio;
     double pos = 0;
@@ -212,6 +212,10 @@ int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
     int i;
     int fill;
 
+    if (src->align == 0) {
+	fprintf(stderr, "Illegal wave align == 0\n");
+	return 0;
+    }
     if (src->align != (channels*bps/8)) {
 	fprintf(stderr, "Unsupported non-PCM convert to mono: align:%d != (channels:%d*bps:%d/8)\n", src->align , channels, bps);
 	return 0;
@@ -224,6 +228,7 @@ int wav_convert2mono(struct WAV*src, struct WAV*dest, int rate)
     dest->tag = src->tag;
     dest->bytesPerSec = dest->sampsPerSec*dest->align;
 
+    samplelen=(src->size+(src->align-1))/src->align; // round up
     ratio = (double)dest->sampsPerSec/(double)src->sampsPerSec;
     fill = (int)(ratio+1)*2;
     


### PR DESCRIPTION
Make sure src->align is non-zero.
Avoid div 0 of align as denominator in samplelen calculation.

ref) https://github.com/matthiaskramm/swftools/issues/57