### PR TITLE
fixing to png_load vulnerability

### DIFF
--- a/lib/png.c
+++ b/lib/png.c
@@ -536,9 +536,11 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
 	}
 	if(!strncmp(tagid, "tRNS", 4)) {
 	    if(header.mode == 3) {
-		alphapalette = data;
-		alphapalettelen = len;
-		data = 0; //don't free data
+		if(!alphapalette) { // guard from redundant tRNS
+		    alphapalette = data;
+		    alphapalettelen = len;
+		    data = 0; //don't free data
+		}
 		//printf("found %d alpha colors\n", alphapalettelen);
 	    } else if(header.mode == 0 || header.mode == 2) {
 		int t;

--- a/lib/png.c
+++ b/lib/png.c
@@ -491,7 +491,7 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
     unsigned char *scanline;
 
     if ((fi = fopen(sname, "rb")) == NULL) {
-	printf("Couldn't open %s\n", sname);
+	fprintf(stderr, "Couldn't open %s\n", sname);
 	return 0;
     }
 
@@ -505,7 +505,7 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
     else if(header.mode == 2) bypp = 3;
     else if(header.mode == 6) bypp = 4;
     else {
-	printf("ERROR: mode:%d\n", header.mode);
+	fprintf(stderr, "ERROR: mode:%d\n", header.mode);
 	return 0;
     }
 
@@ -576,7 +576,7 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
     
     fclose(fi);
     if(!zimagedata || uncompress(imagedata, &imagedatalen, zimagedata, zimagedatalen) != Z_OK) {
-	printf("Couldn't uncompress %s!\n", sname);
+	fprintf(stderr, "Couldn't uncompress sname:%s!\n", sname);
 	if(zimagedata)
 	    free(zimagedata);
 	return 0;
@@ -774,7 +774,7 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
 	free(rgba);
         free(imagedata);
     } else {
-	printf("expected PNG mode to be 2, 3 or 6 (is:%d)\n", header.mode);
+	fprintf(stderr, "expected PNG mode to be 2, 3 or 6 (is:%d)\n", header.mode);
 	return 0;
     }
 

--- a/lib/png.c
+++ b/lib/png.c
@@ -545,11 +545,15 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
 	    } else if(header.mode == 0 || header.mode == 2) {
 		int t;
 		if(header.mode == 2) {
-		    alphacolor[0] = data[1];
-		    alphacolor[1] = data[3];
-		    alphacolor[2] = data[5];
+		    if(len > 5) {
+			alphacolor[0] = data[1];
+			alphacolor[1] = data[3];
+			alphacolor[2] = data[5];
+		    }
 		} else {
-		    alphacolor[0] = alphacolor[1] = alphacolor[2] = data[1];
+		    if(len > 1) {
+			alphacolor[0] = alphacolor[1] = alphacolor[2] = data[1];
+		    }
 		}
 		hasalphacolor = 1;
 	    }

--- a/lib/png.c
+++ b/lib/png.c
@@ -515,6 +515,10 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
 	return 0;
     unsigned long imagedatalen = (unsigned long)imagedatalen_64;
     imagedata = (unsigned char*)malloc(imagedatalen);
+    if (!imagedata) {
+	fprintf(stderr, "ERROR: malloc imagedatalen:%lu\n", imagedatalen);
+	return 0;
+    }
 
     fseek(fi,8,SEEK_SET);
     while(!feof(fi))
@@ -552,6 +556,12 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
 	    if(!zimagedata) {
 		zimagedatalen = len;
 		zimagedata = (unsigned char*)malloc(len);
+		if(!zimagedata) {
+		    fprintf(stderr, "ERROR: malloc zimagedata len:%d\n", len);
+		    free(imagedata);
+		    free(alphapalette);
+		    return 0;
+		}
 		memcpy(zimagedata,data,len);
 	    } else {
 		zimagedata = (unsigned char*)realloc(zimagedata, zimagedatalen+len);
@@ -596,6 +606,12 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
 	return 0;
     }
     data2 = (unsigned char*)malloc((size_t)alloclen_64);
+    if(!data2) {
+	fprintf(stderr, "ERROR: malloc alloclen_64:%d\n", len);
+	free(imagedata);
+	free(alphapalette);
+	return 0;
+    }
 
     if(header.mode == 4)
     {

--- a/lib/png.c
+++ b/lib/png.c
@@ -496,6 +496,7 @@ EXPORT int png_load(const char*sname, unsigned*destwidth, unsigned*destheight, u
     }
 
     if(!png_read_header(fi, &header)) {
+	fprintf(stderr, "Couldn't png read header %s\n", sname);
 	fclose(fi);
 	return 0;
     }

--- a/src/png2swf.c
+++ b/src/png2swf.c
@@ -473,7 +473,10 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id)
     if(global.mkjpeg) {
 #ifdef HAVE_JPEGLIB
 	RGBA*data = 0;
-	png_load(sname, &width, &height, (unsigned char**)&data);
+	if(!png_load(sname, &width, &height, (unsigned char**)&data)) {
+	    msg("<fatal>  Failed to load from %s", sname);
+	    exit(1);
+	}
 	if(!data) 
 	    exit(1);
 	if(swf_ImageHasAlpha(data, width, height)) {
@@ -488,7 +491,10 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id)
 #endif
     } else {
 	RGBA*data = 0;
-	png_load(sname, &width, &height, (unsigned char**)&data);
+	if(!png_load(sname, &width, &height, (unsigned char**)&data)) {
+	    msg("<fatal>  Failed to load from %s", sname);
+	    exit(1);
+	}
 	if(!data) 
 	    exit(1);
 	t = swf_InsertTag(t, ST_DEFINEBITSLOSSLESS);

--- a/src/swfc.c
+++ b/src/swfc.c
@@ -1495,7 +1495,10 @@ void s_image(const char*name, const char*type, const char*filename, int quality)
 	RGBA*data = 0;
 	swf_SetU16(tag, imageID);
 
-	png_load(filename, &width, &height, (unsigned char**)&data);
+	if(!png_load(filename, &width, &height, (unsigned char**)&data)) {
+	    msg("<error>  Failed to load from %s", filename);
+	    return;
+	}
 
 	if(!data) {
 	    syntaxerror("Image \"%s\" not found, or contains errors", filename);


### PR DESCRIPTION
I made the following fixes to png_load function.

- fix to memory leak
   - https://github.com/matthiaskramm/swftools/issues/49
   - guard from redundant tRNS
- malloc NULL check
   - https://github.com/matthiaskramm/swftools/issues/51
- fix to tRNS heap overflow in mode 0, 2
   - (maybe not assigned to issues.)
- retval checking & abend processing.
   - caller of  png_read_header
   - caller of png_load (png2swf, swfc)

# Notes

The  mode:2(RGB24) tRNS palette processing is incorrect.
It's not a degrade. that has existed before.

| PNG | SWF( screenshot) |
|---|---|
| ![Opaopa-png24-trns](https://user-images.githubusercontent.com/26040/72748001-80adf100-3bf9-11ea-8489-fd39cc27fd93.png) | <img width="120" alt="output.swf.png" src="https://user-images.githubusercontent.com/26040/72748032-94f1ee00-3bf9-11ea-9d5b-4ea44e4c2c21.png"> |
