### PR TITLE
Compile popplercompat.cc using the C++ compiler, not the C compiler.

### DIFF
--- a/lib/pdf/Makefile.in
+++ b/lib/pdf/Makefile.in
@@ -36,7 +36,7 @@ splash_objects = xpdf/SplashOutputDev.$(O) xpdf/SplashFont.$(O) xpdf/SplashState
 xpdf_include = @xpdf_include@
 
 popplercompat.$(O): popplercompat.cc
-	$(C) -I ./ $(xpdf_include) popplercompat.cc -o $@
+	$(CC) -I ./ $(xpdf_include) popplercompat.cc -o $@
 fonts.$(O): fonts.c
 	$(C) fonts.c -o $@
 bbox.$(O): bbox.c


### PR DESCRIPTION
Compile popplercompat.cc using the C++ compiler, not the C compiler.

Extract commits from https://github.com/matthiaskramm/swftools/pull/44

```
% git cherry-pick 50914eb2ded1f05eb6387460714a8aa30893e810
```