### PR TITLE
Fixed warning due to missing gfxdevice_dummy_init declaration.

### DIFF
--- a/lib/devices/record.c
+++ b/lib/devices/record.c
@@ -44,6 +44,7 @@
 #include "../fastlz.h"
 #endif
 #include "record.h"
+#include "dummy.h"
 
 //#define STATS
 //#define COMPRESS_IMAGES


### PR DESCRIPTION
Fixed warning due to missing gfxdevice_dummy_init declaration.

Extract commits from https://github.com/matthiaskramm/swftools/pull/44

```
% git cherry-pick 039e0563af263d258411c000697694eb63a7457d
```
