### PR TITLE
bugfix: character existence check of pos1, pos2

### DIFF
--- a/lib/pdf/xpdf-changes.patch
+++ b/lib/pdf/xpdf-changes.patch
@@ -467,9 +467,9 @@
 +    char* p = pos1>pos2?pos1:pos2;
 +    int pos = p ? p-cfgFileName : -1;
 +    GString*path = new GString(new GString(cfgFileName), 0, (pos < 0 ? strlen(cfgFileName): pos));
-+    if(pos1>=0)
++    if(pos1)
 +	path->append('/');
-+    else if(pos2>=0)
++    else if(pos2)
 +	path->append('\\');
 +    else
 +#ifdef WIN32


### PR DESCRIPTION
bugfix: character existence check of pos1, pos2 which is the return value of strrchr.
patch file for lib/pdf/xpdf/GlobalParams.cc

This bug cause errors when compiling on macOS.

# environment

- macOS Catalina 10.15.2
- Xcode 11.1
- cc Apple clang version 11.0.0

# console log
```
xpdf/GlobalParams.cc:925:12: error: ordered comparison between pointer and zero
      ('char *' and 'int')
    if(pos1>=0)
       ~~~~^ ~
xpdf/GlobalParams.cc:927:17: error: ordered comparison between pointer and zero
      ('char *' and 'int')
    else if(pos2>=0)
```