### PR TITLE
src/swfc-history.h include guard malfunction

### DIFF
--- a/src/swfc-history.h
+++ b/src/swfc-history.h
@@ -20,7 +20,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #ifndef __HISTORY_H
-#define __HISTORY_Y
+#define __HISTORY_H
 
 #include "../lib/types.h"
 #include "../lib/rfxswf.h"


### PR DESCRIPTION
fixing to typo __HISTORY_Y => __HISTORY_H
(This is not harmful to actual operation, a potential problem.)

macOS clang compiler display the following warning.

```
./swfc-history.h:22:9: warning: '__HISTORY_H' is used as a header guard here,
      followed by #define of a different macro [-Wheader-guard]
#ifndef __HISTORY_H
        ^~~~~~~~~~~
./swfc-history.h:23:9: note: '__HISTORY_Y' is defined here; did you mean
      '__HISTORY_H'?
#define __HISTORY_Y
        ^~~~~~~~~~~
        __HISTORY_H
```
