### PR TITLE
I want git2swf to work before giflib-5.1.0.

### DIFF
--- a/src/gif2swf.c
+++ b/src/gif2swf.c
@@ -242,7 +242,7 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id, int imgidx)
     }
 
     if ((ret = DGifSlurp(gft)) != GIF_OK) {
-#if !defined(GIFLIB_MAJOR)  // ungif
+#if !defined(GIFLIB_MAJOR)  // libungif
         PrintGifError();
 #elif GIFLIB_MAJOR < 5
         fprintf(stderr, "GIF-LIB: %s\n", GifErrorString());
@@ -525,7 +525,7 @@ int CheckInputFile(char *fname, char **realname)
         global.max_image_height = gft->SHeight;
 
     if ((ret = DGifSlurp(gft)) != GIF_OK) {
-#if !defined(GIFLIB_MAJOR)  // ungif
+#if !defined(GIFLIB_MAJOR)  // libungif
         PrintGifError();
 #elif GIFLIB_MAJOR < 5
         fprintf(stderr, "GIF-LIB: %s\n", GifErrorString());

--- a/src/gif2swf.c
+++ b/src/gif2swf.c
@@ -243,7 +243,7 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id, int imgidx)
 
     if ((ret = DGifSlurp(gft)) != GIF_OK) {
 #if !defined(GIFLIB_MAJOR)  // ungif
-		PrintGifError();
+        PrintGifError();
 #elif GIFLIB_MAJOR < 5
         fprintf(stderr, "GIF-LIB: %s\n", GifErrorString());
 #else
@@ -474,7 +474,7 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id, int imgidx)
 #if GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1 || GIFLIB_MAJOR > 5
     DGifCloseFile(gft, D_GIF_SUCCEEDED);
 #else
-	DGifCloseFile(gft);
+    DGifCloseFile(gft);
 #endif
 
     return t;
@@ -526,7 +526,7 @@ int CheckInputFile(char *fname, char **realname)
 
     if ((ret = DGifSlurp(gft)) != GIF_OK) {
 #if !defined(GIFLIB_MAJOR)  // ungif
-		PrintGifError();
+        PrintGifError();
 #elif GIFLIB_MAJOR < 5
         fprintf(stderr, "GIF-LIB: %s\n", GifErrorString());
 #else
@@ -553,7 +553,7 @@ int CheckInputFile(char *fname, char **realname)
 #if GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1 || GIFLIB_MAJOR > 5
     DGifCloseFile(gft, D_GIF_SUCCEEDED);
 #else
-	DGifCloseFile(gft);
+    DGifCloseFile(gft);
 #endif
 
     return 0;

--- a/src/gif2swf.c
+++ b/src/gif2swf.c
@@ -468,7 +468,12 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id, int imgidx)
 
     free(pal);
     free(imagedata);
+
+#if GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1 || GIFLIB_MAJOR > 5
     DGifCloseFile(gft, D_GIF_SUCCEEDED);
+#else
+	DGifCloseFile(gft);
+#endif
 
     return t;
 }
@@ -541,7 +546,11 @@ int CheckInputFile(char *fname, char **realname)
             fprintf(stderr, "frame: %u, delay: %.3f sec\n", i + 1, getGifDelayTime(gft, i) / 100.0);
     }
 
+#if GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1 || GIFLIB_MAJOR > 5
     DGifCloseFile(gft, D_GIF_SUCCEEDED);
+#else
+	DGifCloseFile(gft);
+#endif
 
     return 0;
 }

--- a/src/gif2swf.c
+++ b/src/gif2swf.c
@@ -242,10 +242,12 @@ TAG *MovieAddFrame(SWF * swf, TAG * t, char *sname, int id, int imgidx)
     }
 
     if ((ret = DGifSlurp(gft)) != GIF_OK) {
-#if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR >= 5
-        fprintf(stderr, "GIF-LIB: %s\n", GifErrorString(ret));
+#if !defined(GIFLIB_MAJOR)  // ungif
+		PrintGifError();
+#elif GIFLIB_MAJOR < 5
+        fprintf(stderr, "GIF-LIB: %s\n", GifErrorString());
 #else
-        PrintGifError();
+        fprintf(stderr, "GIF-LIB: %s\n", GifErrorString(ret));
 #endif
         return t;
     }
@@ -523,10 +525,12 @@ int CheckInputFile(char *fname, char **realname)
         global.max_image_height = gft->SHeight;
 
     if ((ret = DGifSlurp(gft)) != GIF_OK) {
-#if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR >= 5
-        fprintf(stderr, "GIF-LIB: %s\n", GifErrorString(ret));
+#if !defined(GIFLIB_MAJOR)  // ungif
+		PrintGifError();
+#elif GIFLIB_MAJOR < 5
+        fprintf(stderr, "GIF-LIB: %s\n", GifErrorString());
 #else
-        PrintGifError();
+        fprintf(stderr, "GIF-LIB: %s\n", GifErrorString(ret));
 #endif
         return -1;
     }


### PR DESCRIPTION
- EGifCloseFile, DGifCloseFile API changed destructively in giflib-5.1.0
- PrintGifError only works with libungif-4.x.x
- GifErrorString argument added in giflib-5.0.0

ref) https://github.com/matthiaskramm/swftools/pull/2/files