### PR TITLE
swfextract: move jpeg app0 to start of file

### DIFF
--- a/src/swfextract.c
+++ b/src/swfextract.c
@@ -749,10 +749,21 @@ int handlejpeg(TAG*tag)
 	int end = tag->len;
 	int pos = findjpegboundary(&tag->data[2], tag->len-2);
 	if(pos>=0) {
+            int skip1=0;
+            int skip2=0;
             pos+=2;
             fi = save_fopen(filename, "wb");
-            fwrite(&tag->data[2], pos-2, 1, fi);
-            fwrite(&tag->data[pos+4], end-(pos+4), 1, fi);
+            if (end-pos > 8 && tag->data[pos+4] == 0xff && tag->data[pos+5] == 0xe0) { // app0 in second? move it
+                int len = 2+GET16(&tag->data[pos+6]);
+                if (pos+4+len <= end && tag->data[0] == 0xff && tag->data[1] == 0xd8) {
+                    skip1 = 2;
+                    skip2 = len;
+                    fwrite(&tag->data[2], skip1, 1, fi); // write soi
+                    fwrite(&tag->data[pos+4], skip2, 1, fi); // write app0
+                }
+            }
+            fwrite(&tag->data[2+skip1], pos-2-skip1, 1, fi);
+            fwrite(&tag->data[pos+4+skip2], end-(pos+4+skip2), 1, fi);
             fclose(fi);
         } else {
             fi = save_fopen(filename, "wb");


### PR DESCRIPTION
Sometimes the jpeg app0 header is in the second part of the definebitsjpeg2 tag data, most applications can't handle that. Move it to the start when extracting.
[example-swf.zip](https://github.com/matthiaskramm/swftools/files/4534883/example-swf.zip)
