### PR TITLE
Fix Name and ClipDepth order

### DIFF
--- a/lib/modules/swfobject.c
+++ b/lib/modules/swfobject.c
@@ -79,9 +79,8 @@ static int objectplace(TAG * t,U16 id,U16 depth,MATRIX * m,CXFORM * cx,const cha
   if (flags&PF_MATRIX) swf_SetMatrix(t,m);
   if (flags&PF_CXFORM) swf_SetCXForm(t,cx,1);
   if (flags&PF_RATIO) swf_SetU16(t,0);
-  /* ??? The spec states that name comes first? */
-  if (flags&PF_CLIPDEPTH) swf_SetU16(t, clipaction);
   if (flags&PF_NAME) swf_SetString(t,name);
+  if (flags&PF_CLIPDEPTH) swf_SetU16(t, clipaction);
 	
   if (flags2&PF2_BLENDMODE)
     swf_SetU8(t,blendmode);
@@ -133,9 +132,8 @@ void swf_SetPlaceObject(TAG * t,SWFPLACEOBJECT* obj)
 	if (flags&PF_CXFORM) swf_SetCXForm(t,&obj->cxform,1);
 	if (flags&PF_RATIO) swf_SetU16(t,obj->ratio);
   
-	/* ??? The spec states that name comes first? */
-	if (flags&PF_CLIPDEPTH) swf_SetU16(t,obj->clipdepth);
 	if (flags&PF_NAME) swf_SetString(t,obj->name);
+	if (flags&PF_CLIPDEPTH) swf_SetU16(t,obj->clipdepth);
 
 	if (flags2&PF2_FILTERS) {
 	    swf_SetU8(t,obj->filters->num);
@@ -190,8 +188,6 @@ void swf_GetPlaceObject(TAG * tag,SWFPLACEOBJECT* obj)
         if(flags&PF_RATIO) obj->ratio = swf_GetU16(tag);
         /* if you modify the order of these operations, also
            modify it in ../src/swfcombine.c */
-        if(flags&PF_CLIPDEPTH) 
-            obj->clipdepth = swf_GetU16(tag); //clip
         if(flags&PF_NAME) {
             int l,t;
             U8*data;
@@ -202,6 +198,8 @@ void swf_GetPlaceObject(TAG * tag,SWFPLACEOBJECT* obj)
             obj->name = (char*)data;
             while((data[t++] = swf_GetU8(tag))); 
         }
+        if(flags&PF_CLIPDEPTH) 
+            obj->clipdepth = swf_GetU16(tag); //clip
 	if(flags2&PF2_BLENDMODE) {
 	    obj->blendmode = swf_GetU8(tag);
 	}

--- a/lib/modules/swftools.c
+++ b/lib/modules/swftools.c
@@ -410,12 +410,12 @@ char* swf_GetName(TAG * t)
               swf_GetCXForm(t, &c, 1);
             if(flags&PF_RATIO)
               swf_GetU16(t);
-            if(flags&PF_CLIPDEPTH)
-              swf_GetU16(t);
             if(flags&PF_NAME) {
               swf_ResetReadBits(t);
               name = (char*)&t->data[swf_GetTagPos(t)];
             }
+            if(flags&PF_CLIPDEPTH)
+              swf_GetU16(t);
         }
         break;
     }

--- a/src/swfdump.c
+++ b/src/swfdump.c
@@ -722,6 +722,7 @@ void handlePlaceObject23(TAG*tag, char*prefix)
 	    ppos[2] += sprintf(pstr[2]+ppos[2], "|       ");
 	}
     }
+    if(flags&32) { while(swf_GetU8(tag)); }
     if(flags&64) {
 	U16 clip = swf_GetU16(tag); //clip
 	if(placements) {
@@ -730,7 +731,6 @@ void handlePlaceObject23(TAG*tag, char*prefix)
 	    ppos[2] += sprintf(pstr[2]+ppos[2], "|       ");
 	}
     }
-    if(flags&32) { while(swf_GetU8(tag)); }
 
     if(flags2&1) { // filter list
 	U8 num = swf_GetU8(tag);


### PR DESCRIPTION
Swftools deviates from the [official swf specification](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf). This deviation causes Flash to misinterpret some of the swf files generated by swfc.

From PLACEOBJECT2 section:
<img width="852" alt="Screenshot 2020-07-08 at 12 05 41" src="https://user-images.githubusercontent.com/6103818/86906146-661df480-c113-11ea-94f2-fba6147cedac.png">

The specification states, that ClipDepth field comes after the Name field. 

This has been in the code for 15 years according to git blame:
https://github.com/matthiaskramm/swftools/commit/d193d733dfa41679452284e4e60e7237ac721cba#diff-b0ead3b01c9deed99d0df1f51970d65cR124

Here is a swfc script which demonstrates an issue caused by this difference:

```
.flash
    .circle cg 200 fill=green line=1
    .circle cb 200 fill=blue line=1
    .circle cr 200 fill=red line=1

    .startclip cg x=0 y=0
        .put cb x=0 y=200
    .end

    .put cr y=0 x=200
.end
```

The problem is, that the green circle (cg) should only mask the blue circle (cb), but it also masks the red circle (cr), because the clip depth is read in from the name field (becoming some garbage, large value) by Flash.

This is how flash renders the resulting swf (bad.swf) (generated on master):
<img width="440" alt="screen shot 2017-07-18 at 21 46 00" src="https://user-images.githubusercontent.com/6103818/28336815-a922b1c0-6c03-11e7-9bac-81c786aca870.png">

This is how it should look like (good.swf) (generated on this branch):
<img width="638" alt="screen shot 2017-07-18 at 21 45 43" src="https://user-images.githubusercontent.com/6103818/28336817-ab3e7a34-6c03-11e7-9148-ca0ac7400923.png">

You can find the two files above in [swfs.zip](https://github.com/matthiaskramm/swftools/files/4890136/swfs.zip) 

Fixes https://github.com/matthiaskramm/swftools/issues/40