### PR TITLE
Optimize previous patch (#148)

### DIFF
--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -711,27 +711,28 @@ int main(int argn, char *argv[])
 	show_info(driver, filename);
 	return 0;
     }
-
-    char*u = 0;
-    if((u = strchr(outputname, '%'))) {
-	if(strchr(u+1, '%') || 
-	   strchr(outputname, '%')!=u)  {
-	    msg("<error> only one %% allowed in filename\n");
-	    return 1;
-	}
-	if(preloader || viewer) {
-	    msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
-	    return 1;
-	}
-	msg("<notice> outputting one file per page");
-	one_file_per_page = 1;
-	char*pattern = (char*)malloc(strlen(outputname)+2);
-	/* convert % to %d */
-	int l = u-outputname+1;
-	memcpy(pattern, outputname, l);
-	pattern[l]='d';
-	strcpy(pattern+l+1, outputname+l);
-	outputname = pattern;
+    if(!strchr(outputname, '\\')){
+	    char*u = 0;
+	    if((u = strchr(outputname, '%'))) {
+		if(strchr(u+1, '%') || 
+		   strchr(outputname, '%')!=u)  {
+		    msg("<error> only one %% allowed in filename\n");
+		    return 1;
+		}
+		if(preloader || viewer) {
+		    msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
+		    return 1;
+		}
+		msg("<notice> outputting one file per page");
+		one_file_per_page = 1;
+		char*pattern = (char*)malloc(strlen(outputname)+2);
+		/* convert % to %d */
+		int l = u-outputname+1;
+		memcpy(pattern, outputname, l);
+		pattern[l]='d';
+		strcpy(pattern+l+1, outputname+l);
+		outputname = pattern;
+	    }
     }
 
     gfxdocument_t* pdf = driver->open(driver, filename);

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -735,7 +735,7 @@ int main(int argn, char *argv[])
 	}
     }
     if(checkoutputname){
-	char*u = 0;
+    	char*u = 0;
 	if((u = strchr(optoken, '%')))
 	    if(strchr(u+1, '%') || strchr(optoken, '%')!=u) {
 		msg("<error> only one %% allowed in filename\n");

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -718,11 +718,11 @@ int main(int argn, char *argv[])
     char*match = 0;
     int len; 
     if(lastocc != NULL) {
-    	optoken = lastocc+1;
+        optoken = lastocc+1;
     }
     char*v = 0;
     if((v = strchr(optoken, '\\'))) {
-    	if(strchr(v+1, '%')) {
+        if(strchr(v+1, '%')) {
     	    checkoutputname = 0;
     	    char*bsl = "\\";
     	    match = optoken;
@@ -762,9 +762,9 @@ int main(int argn, char *argv[])
     		    match++;
     		}
     		strcat(outputname, pattern); 
-    	    }else{
-    		outputname = pattern;
-	    }
+    	}else{
+    	outputname = pattern;
+    	    }
     	}
     }
 

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -767,6 +767,7 @@ int main(int argn, char *argv[])
             }
     	}
     }
+
     gfxdocument_t* pdf = driver->open(driver, filename);
     if(!pdf) {
         msg("<error> Couldn't open %s", filename);

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -735,37 +735,37 @@ int main(int argn, char *argv[])
 	}
     }
     if(checkoutputname){
-    	char*u = 0;
-	if((u = strchr(optoken, '%'))) {
-            if(strchr(u+1, '%') || strchr(optoken, '%')!=u) {
-                msg("<error> only one %% allowed in filename\n");
+	char*u = 0;
+	if((u = strchr(optoken, '%')))
+	    if(strchr(u+1, '%') || strchr(optoken, '%')!=u) {
+		msg("<error> only one %% allowed in filename\n");
 		return 1;
-            }
-            if(preloader || viewer) {
-                msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
-                return 1;
-            }
-            msg("<notice> outputting one file per page");
-            one_file_per_page = 1;
-            char*pattern = (char*)malloc(strlen(optoken)+2);
-            /* convert % to %d */
-            int l = u-optoken+1;
-            memcpy(pattern, optoken, l);
-            pattern[l]='d';
-            strcpy(pattern+l+1, optoken+l);
-            if(lastocc != NULL){
-                match = strdup(outputname);
-                len = strlen(optoken);
-                while((match = strstr(outputname, optoken))) {
-                    *match = '\0';
-                    strcat(outputname, match+len);
-                    match++;
-                }
-                strcat(outputname, pattern); 
-            }else{
-                outputname = pattern;
-            }
-    	}
+	    }
+	    if(preloader || viewer) {
+		msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
+		return 1;
+	    }
+	    msg("<notice> outputting one file per page");
+	    one_file_per_page = 1;
+	    char*pattern = (char*)malloc(strlen(optoken)+2);
+	    /* convert % to %d */
+	    int l = u-optoken+1;
+	    memcpy(pattern, optoken, l);
+	    pattern[l]='d';
+	    strcpy(pattern+l+1, optoken+l);
+	    if(lastocc != NULL){
+		match = strdup(outputname);
+		len = strlen(optoken);
+		while((match = strstr(outputname, optoken))) {
+		    *match = '\0';
+		    strcat(outputname, match+len);
+		    match++;
+		}
+		strcat(outputname, pattern); 
+	    }else{
+	    	outputname = pattern;
+	    }
+	}
     }
 
     gfxdocument_t* pdf = driver->open(driver, filename);

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -718,21 +718,21 @@ int main(int argn, char *argv[])
     char*match = 0;
     int len; 
     if(lastocc != NULL) {
-        optoken = lastocc+1;
+	optoken = lastocc+1;
     }
     char*v = 0;
     if((v = strchr(optoken, '\\'))) {
-        if(strchr(v+1, '%')) {
-            checkoutputname = 0;
-            char*bsl = "\\";
-            match = optoken;
-            len = strlen(bsl);
-            while((match = strstr(match, bsl))) {
-                *match = '\0';
-                strcat(optoken, match+len);
-                match++;
-            }
-        }
+	if(strchr(v+1, '%')) {
+	    checkoutputname = 0;
+	    char*bsl = "\\";
+	    match = optoken;
+	    len = strlen(bsl);
+	    while((match = strstr(match, bsl))) {
+		*match = '\0';
+		strcat(optoken, match+len);
+		match++;
+	    }
+	}
     }
     if(checkoutputname){
     	char*u = 0;

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -762,8 +762,8 @@ int main(int argn, char *argv[])
     		    match++;
     		}
     		strcat(outputname, pattern); 
-    	}else{
-            outputname = pattern;
+    	    }else{
+                outputname = pattern;
     	    }
     	}
     }

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -718,54 +718,54 @@ int main(int argn, char *argv[])
     char*match = 0;
     int len; 
     if(lastocc != NULL) {
-	optoken = lastocc+1;
+    	optoken = lastocc+1;
     }
     char*v = 0;
     if((v = strchr(optoken, '\\'))) {
-	if(strchr(v+1, '%')) {
-	    checkoutputname = 0;
-	    char*bsl = "\\";
-	    match = optoken;
-	    len = strlen(bsl);
-	    while((match = strstr(match, bsl))) {
-		*match = '\0';
-		strcat(optoken, match+len);
-		match++;
-	    }
-	}
+    	if(strchr(v+1, '%')) {
+    	    checkoutputname = 0;
+    	    char*bsl = "\\";
+    	    match = optoken;
+    	    len = strlen(bsl);
+    	    while((match = strstr(match, bsl))) {
+    	    	*match = '\0';
+    	    	strcat(optoken, match+len);
+    	    	match++;
+    	    }
+    	}
     }
     if(checkoutputname){
     	char*u = 0;
-	if((u = strchr(optoken, '%')))
-	    if(strchr(u+1, '%') || strchr(optoken, '%')!=u) {
-		msg("<error> only one %% allowed in filename\n");
-		return 1;
+    	if((u = strchr(optoken, '%')))
+    	    if(strchr(u+1, '%') || strchr(optoken, '%')!=u) {
+    		msg("<error> only one %% allowed in filename\n");
+    		return 1;
+    	    }
+    	    if(preloader || viewer) {
+    		msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
+    		return 1;
+    	    }
+    	    msg("<notice> outputting one file per page");
+    	    one_file_per_page = 1;
+    	    char*pattern = (char*)malloc(strlen(optoken)+2);
+    	    /* convert % to %d */
+    	    int l = u-optoken+1;
+    	    memcpy(pattern, optoken, l);
+    	    pattern[l]='d';
+    	    strcpy(pattern+l+1, optoken+l);
+    	    if(lastocc != NULL){
+    		match = strdup(outputname);
+    		len = strlen(optoken);
+    		while((match = strstr(outputname, optoken))) {
+    		    *match = '\0';
+    		    strcat(outputname, match+len);
+    		    match++;
+    		}
+    		strcat(outputname, pattern); 
+    	    }else{
+    		outputname = pattern;
 	    }
-	    if(preloader || viewer) {
-		msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
-		return 1;
-	    }
-	    msg("<notice> outputting one file per page");
-	    one_file_per_page = 1;
-	    char*pattern = (char*)malloc(strlen(optoken)+2);
-	    /* convert % to %d */
-	    int l = u-optoken+1;
-	    memcpy(pattern, optoken, l);
-	    pattern[l]='d';
-	    strcpy(pattern+l+1, optoken+l);
-	    if(lastocc != NULL){
-		match = strdup(outputname);
-		len = strlen(optoken);
-		while((match = strstr(outputname, optoken))) {
-		    *match = '\0';
-		    strcat(outputname, match+len);
-		    match++;
-		}
-		strcat(outputname, pattern); 
-	    }else{
-	    	outputname = pattern;
-	    }
-	}
+    	}
     }
 
     gfxdocument_t* pdf = driver->open(driver, filename);

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -763,7 +763,7 @@ int main(int argn, char *argv[])
     		}
     		strcat(outputname, pattern); 
     	}else{
-    	outputname = pattern;
+            outputname = pattern;
     	    }
     	}
     }

--- a/src/pdf2swf.c
+++ b/src/pdf2swf.c
@@ -711,30 +711,62 @@ int main(int argn, char *argv[])
 	show_info(driver, filename);
 	return 0;
     }
-    if(!strchr(outputname, '\\')){
-	    char*u = 0;
-	    if((u = strchr(outputname, '%'))) {
-		if(strchr(u+1, '%') || 
-		   strchr(outputname, '%')!=u)  {
-		    msg("<error> only one %% allowed in filename\n");
-		    return 1;
-		}
-		if(preloader || viewer) {
-		    msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
-		    return 1;
-		}
-		msg("<notice> outputting one file per page");
-		one_file_per_page = 1;
-		char*pattern = (char*)malloc(strlen(outputname)+2);
-		/* convert % to %d */
-		int l = u-outputname+1;
-		memcpy(pattern, outputname, l);
-		pattern[l]='d';
-		strcpy(pattern+l+1, outputname+l);
-		outputname = pattern;
-	    }
-    }
 
+    int checkoutputname = 1;
+    char*optoken = strdup(outputname);; 
+    char*lastocc = strrchr(optoken, '/');
+    char*match = 0;
+    int len; 
+    if(lastocc != NULL) {
+        optoken = lastocc+1;
+    }
+    char*v = 0;
+    if((v = strchr(optoken, '\\'))) {
+        if(strchr(v+1, '%')) {
+            checkoutputname = 0;
+            char*bsl = "\\";
+            match = optoken;
+            len = strlen(bsl);
+            while((match = strstr(match, bsl))) {
+                *match = '\0';
+                strcat(optoken, match+len);
+                match++;
+            }
+        }
+    }
+    if(checkoutputname){
+    	char*u = 0;
+	if((u = strchr(optoken, '%'))) {
+            if(strchr(u+1, '%') || strchr(optoken, '%')!=u) {
+                msg("<error> only one %% allowed in filename\n");
+		return 1;
+            }
+            if(preloader || viewer) {
+                msg("<error> -b/-l/-B/-L not supported together with %% in filename\n");
+                return 1;
+            }
+            msg("<notice> outputting one file per page");
+            one_file_per_page = 1;
+            char*pattern = (char*)malloc(strlen(optoken)+2);
+            /* convert % to %d */
+            int l = u-optoken+1;
+            memcpy(pattern, optoken, l);
+            pattern[l]='d';
+            strcpy(pattern+l+1, optoken+l);
+            if(lastocc != NULL){
+                match = strdup(outputname);
+                len = strlen(optoken);
+                while((match = strstr(outputname, optoken))) {
+                    *match = '\0';
+                    strcat(outputname, match+len);
+                    match++;
+                }
+                strcat(outputname, pattern); 
+            }else{
+                outputname = pattern;
+            }
+    	}
+    }
     gfxdocument_t* pdf = driver->open(driver, filename);
     if(!pdf) {
         msg("<error> Couldn't open %s", filename);


### PR DESCRIPTION
the char '%' can be now be used in the file path. If the filename contains '%' so pdf2swf will interpret it as usual (split pages). If it contains '\%' it will be considered as a normal char and will skip the split pages logic.