### PR TITLE
zlib stream original size exactly calculation in lossless tag.

### DIFF
--- a/src/swfextract.c
+++ b/src/swfextract.c
@@ -788,7 +788,11 @@ int handlejpeg(TAG*tag)
 
 	uLongf datalen = width*height;
 	Bytef *data = malloc(datalen);
-
+        if(!data) {
+            fprintf(stderr, "malloc error datalen:%ld tag->id:%d\n",
+                    datalen, tag->id);
+            return 0;
+        }
 	int error = uncompress(data, &datalen, &tag->data[end], (uLong)(tag->len - end));
 	if(error != Z_OK) {
 	  fprintf(stderr, "Zlib error %d\n", error);

--- a/src/swfextract.c
+++ b/src/swfextract.c
@@ -650,7 +650,6 @@ int handlefont(SWF*swf, TAG*tag)
     U16 id;
     char name[80];
     char*filename = name;
-    int t;
 
     id = swf_GetDefineID(tag);
     prepare_name(name, sizeof(name), "font", "swf", id);
@@ -884,12 +883,10 @@ int handlelossless(TAG*tag)
     char*filename = name;
     FILE*fi;
     int width, height;
-    int crc;
     int id;
     int t;
     U8 bpp = 1;
     U8 format;
-    U8 tmp;
     Bytef* data=0;
     U8* data2=0;
     U8* data3=0;
@@ -902,7 +899,6 @@ int handlelossless(TAG*tag)
     RGBA* palette;
     int pos;
     int error;
-    U32 tmp32;
 
     make_crc32_table();
 
@@ -931,10 +927,6 @@ int handlelossless(TAG*tag)
     width = swf_GetU16(tag);
     height = swf_GetU16(tag);
     if(format == 3) cols = swf_GetU8(tag) + 1;
-// this is what format means according to the flash specification. (which is
-// clearly wrong)
-//    if(format == 4) cols = swf_GetU16(tag) + 1;
-//    if(format == 5) cols = swf_GetU32(tag) + 1;
     else cols = 0;
 
     msg("<verbose> Width %d", width);

--- a/src/swfextract.c
+++ b/src/swfextract.c
@@ -937,15 +937,7 @@ int handlelossless(TAG*tag)
     msg("<verbose> Alpha %d", alpha);
 
 #define align_width(w, a) (((w) + ((a)-1)) & -(a))
-    if(format == 3) {
-	// row widths in the pixel data field must be rounded up to 32-bit word
-	datalen = (3+alpha)*cols + align_width((uLongf)width, 4)*height;
-    } else if (format == 5) {
-	datalen = 4*(uLongf)width*height;  // XRGB or ARGB
-    } else {  // fail safe
-	fprintf(stderr, "wrong format:%d (image %d)\n",format,id);
-	return 0;
-    }
+    datalen = (3+alpha)*cols + align_width((uLongf)width*(bpp/8), 4)*height;
     data = malloc(datalen);
     if(!data) {
 	fprintf(stderr, "malloc error datalen:%ld tag->id:%d\n",

--- a/src/swfextract.c
+++ b/src/swfextract.c
@@ -963,6 +963,7 @@ int handlelossless(TAG*tag)
     error = uncompress (data, &datalen, &tag->data[tag->pos], tag->len-tag->pos);
     if(error != Z_OK) {
 	fprintf(stderr, "Zlib error %d (image %d)\n", error, id);
+	free(data);
 	return 0;
     }
     msg("<verbose> Uncompressed image is %d bytes (%d colormap)", datalen, (3+alpha)*cols);


### PR DESCRIPTION
- dissmiss incremental malloc & uncompress try loop.
  - calculating accurate datalen value from lossless tag info.
  - fixing to (signed) int overflow & sign flip problem with 32-bit environment.
  - https://github.com/matthiaskramm/swftools/pull/71
- etc
  - check malloc return value.
  - fix to memory leak with corrupted zlib stream.
  - delete unused variables (tmp, tmp32, ...), code comment.
