### PR TITLE
Fix double definition linker errors by marking variables as extern

### DIFF
--- a/lib/as3/registry.h
+++ b/lib/as3/registry.h
@@ -6,7 +6,7 @@
    Part of the swftools package.
 
    Copyright (c) 2008 Matthias Kramm <kramm@quiss.org>
- 
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
@@ -114,7 +114,7 @@ extern type_t slotinfo_type;
 char slotinfo_equals(slotinfo_t*c1, slotinfo_t*c2);
 
 void registry_init();
-        
+
 classinfo_t* classinfo_register(int access, const char*package, const char*name, int num_interfaces);
 methodinfo_t* methodinfo_register_onclass(classinfo_t*cls, U8 access, const char*ns, const char*name, char is_static);
 methodinfo_t* methodinfo_register_global(U8 access, const char*package, const char*name);
@@ -135,7 +135,7 @@ void registry_fill_multiname(multiname_t*m, namespace_t*n, slotinfo_t*c);
     namespace_t m##_ns;\
     (x)->package; \
     registry_fill_multiname(&m, &m##_ns, (slotinfo_t*)(x));
-                    
+
 multiname_t* classinfo_to_multiname(slotinfo_t*cls);
 
 char registry_isfunctionclass();
@@ -153,7 +153,6 @@ void registry_use(slotinfo_t*s);
 asset_bundle_list_t*registry_getassets();
 
 // static multinames
-classinfo_t voidclass;
 classinfo_t* registry_getanytype();
 classinfo_t* registry_getarrayclass();
 classinfo_t* registry_getobjectclass();
@@ -218,7 +217,7 @@ void slotinfo_dump(slotinfo_t*s);
 #define TYPE_IS_XML(t)      ((t) == registry_getxmlclass())
 #define TYPE_XMLLIST        registry_getxmllistclass()
 #define TYPE_IS_XMLLIST(t)  ((t) == registry_getxmllistclass())
-        
+
 #define TYPE_IS_BUILTIN_SIMPLE(type) (TYPE_IS_INT(type) || \
                                       TYPE_IS_UINT(type) || \
                                       TYPE_IS_FLOAT(type) || \

--- a/src/swfc-feedback.h
+++ b/src/swfc-feedback.h
@@ -4,7 +4,7 @@
 
    Copyright (c) 2007 Huub Schaeks <huub@h-schaeks.speedlinq.nl>
    Copyright (c) 2007 Matthias Kramm <kramm@quiss.org>
- 
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
@@ -22,10 +22,10 @@
 #ifndef __FEEDBACK_H
 #define __FEEDBACK_H
 
-char* filename;
-int line;
-int column;
-void (*cleanUp)();
+extern char* filename;
+extern int line;
+extern int column;
+extern void (*cleanUp)();
 
 void syntaxerror(char*format, ...);
 void warning(char*format, ...);

--- a/src/swfc-history.h
+++ b/src/swfc-history.h
@@ -4,7 +4,7 @@
 
    Copyright (c) 2007 Huub Schaeks <huub@h-schaeks.speedlinq.nl>
    Copyright (c) 2007 Matthias Kramm <kramm@quiss.org>
- 
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
@@ -34,7 +34,7 @@ enum
 	CF_CHANGE = 2,
     CF_SCHANGE = 3,
     CF_SWEEP = 4,
-	CF_JUMP = 5	
+	CF_JUMP = 5
 };
 
 #define SF_X 0x0001
@@ -55,11 +55,11 @@ enum
 
 #define IF_FIXED_ALIGNMENT 0x0001
 
-FILTER* noFilters;
-FILTER_BLUR* noBlur;
-FILTER_BEVEL* noBevel;
-FILTER_DROPSHADOW* noDropshadow;
-FILTER_GRADIENTGLOW* noGradientGlow;
+extern FILTER* noFilters;
+extern FILTER_BLUR* noBlur;
+extern FILTER_BEVEL* noBevel;
+extern FILTER_DROPSHADOW* noDropshadow;
+extern FILTER_GRADIENTGLOW* noGradientGlow;
 
 typedef struct _spline
 {


### PR DESCRIPTION
I was getting the following errors when compiling with gcc 10

```
gcc -DHAVE_CONFIG_H parser.o swfc.o swfc-feedback.o swfc-history.o swfc-interpolation.o -o swfc ../lib/librfxswf.a ../lib/libbase.a -L/usr/local/lib -lz -lm 
/usr/bin/ld: swfc-feedback.o:(.bss+0x8): multiple definition of `column'; swfc.o:(.bss+0x38): first defined here
/usr/bin/ld: swfc-feedback.o:(.bss+0xc): multiple definition of `line'; swfc.o:(.bss+0x3c): first defined here
/usr/bin/ld: swfc-feedback.o:(.bss+0x10): multiple definition of `filename'; swfc.o:(.bss+0x40): first defined here
/usr/bin/ld: swfc-feedback.o:(.bss+0x0): multiple definition of `cleanUp'; swfc.o:(.bss+0x30): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x18): multiple definition of `noBlur'; swfc.o:(.bss+0x20): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x8): multiple definition of `noDropshadow'; swfc.o:(.bss+0x10): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x10): multiple definition of `noBevel'; swfc.o:(.bss+0x18): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x0): multiple definition of `noGradientGlow'; swfc.o:(.bss+0x8): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x20): multiple definition of `noFilters'; swfc.o:(.bss+0x28): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x28): multiple definition of `cleanUp'; swfc.o:(.bss+0x30): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x30): multiple definition of `column'; swfc.o:(.bss+0x38): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x34): multiple definition of `line'; swfc.o:(.bss+0x3c): first defined here
/usr/bin/ld: swfc-history.o:(.bss+0x38): multiple definition of `filename'; swfc.o:(.bss+0x40): first defined here
/usr/bin/ld: ../lib/librfxswf.a(compiler.o):(.bss+0x20): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(parser_help.o):(.bss+0x20): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(state.o):(.bss+0x20): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(initcode.o):(.bss+0x0): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(assets.o):(.bss+0x0): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(files.o):(.bss+0x360): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(registry.o):(.data.rel.local+0x80): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(builtin.o):(.bss+0x0): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(tokenizer.yy.o):(.bss+0x20): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(parser.tab.o):(.bss+0x40): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
/usr/bin/ld: ../lib/librfxswf.a(expr.o):(.bss+0x0): multiple definition of `voidclass'; ../lib/librfxswf.a(abc.o):(.bss+0x800): first defined here
collect2: error: ld returned 1 exit status
```

These variables have to be explictally marked as extern so the compiler doesn't reserve space in both object files for the variable. My editor automatically trims trailing whitespace, if you'd prefer to avoid the whitespace changes I can revert them.