### PR TITLE
Fix 'multiple definition of 'point_type' build error

### DIFF
--- a/lib/gfxpoly/convert.h
+++ b/lib/gfxpoly/convert.h
@@ -5,6 +5,8 @@
 #include "../gfxtools.h"
 #include "poly.h"
 
+extern type_t point_type;
+
 typedef struct _polywriter
 {
     void(*moveto)(struct _polywriter*, int32_t x, int32_t y);

--- a/lib/gfxpoly/poly.h
+++ b/lib/gfxpoly/poly.h
@@ -18,7 +18,6 @@ typedef struct _point {
     int32_t x;
     int32_t y;
 } point_t;
-type_t point_type;
 
 #define SEGNR(s) ((int)((s)?(s)->nr:-1))
 


### PR DESCRIPTION
On my machine, these changes correct this build error:

    /usr/bin/ld: ../libgfx.a(poly.o):(.data.rel.local+0x0): multiple definition of `point_type'; ../libgfx.a(convert.o):(.bss+0x0): first defined here
    /usr/bin/ld: ../libgfx.a(stroke.o):(.bss+0x0): multiple definition of `point_type'; ../libgfx.a(convert.o):(.bss+0x0): first defined here
    /usr/bin/ld: ../libgfx.a(wind.o):(.bss+0x20): multiple definition of `point_type'; ../libgfx.a(convert.o):(.bss+0x0): first defined here
    /usr/bin/ld: ../libgfx.a(xrow.o):(.bss+0x0): multiple definition of `point_type'; ../libgfx.a(convert.o):(.bss+0x0): first defined here
    /usr/bin/ld: ../libgfx.a(moments.o):(.bss+0x0): multiple definition of `point_type'; ../libgfx.a(convert.o):(.bss+0x0): first defined here
    /usr/bin/ld: ../libgfx.a(active.o):(.bss+0x0): multiple definition of `point_type'; ../libgfx.a(convert.o):(.bss+0x0): first defined here

In order for `make` to successfully complete, I also had to comment-out `inline` immediately preceding `void bitpressure_strategy1(` in `lib/lame/quantize.c`. The commented-out `inline` is not included in this PR because I don't understand why it worked, since my compiler (gcc 10.21.1 on Debian x64) is fine with the `inline` preceding `void bitpressure_strategy2(`.