### PR TITLE
Fix compilation on arm64 macOS and Linux and gfx2gfx.c

### DIFF
--- a/configure
+++ b/configure
@@ -2814,6 +2814,11 @@ case $host_os in
 	    CPPFLAGS="${CPPFLAGS} -I/opt/local/include"
 	    LDFLAGS="${LDFLAGS} -L/opt/local/lib"
 	fi
+	# Use packages installed by homebrew on Apple Silicon.
+	if test -d /opt/homebrew/include && test -d /opt/homebrew/lib; then
+	    CPPFLAGS="${CPPFLAGS} -I/opt/homebrew/include"
+	    LDFLAGS="${LDFLAGS} -L/opt/homebrew/lib"
+	fi
 	# Use fink packages if available.
 	#if test -d /sw/include && test -d /sw/lib; then
 	#    CPPFLAGS="${CPPFLAGS} -I/sw/include"

--- a/configure.in
+++ b/configure.in
@@ -110,6 +110,11 @@ case $host_os in
 	    CPPFLAGS="${CPPFLAGS} -I/opt/local/include"
 	    LDFLAGS="${LDFLAGS} -L/opt/local/lib"
 	fi
+	# Use packages installed by homebrew on Apple Silicon.
+	if test -d /opt/homebrew/include && test -d /opt/homebrew/lib; then
+	    CPPFLAGS="${CPPFLAGS} -I/opt/homebrew/include"
+	    LDFLAGS="${LDFLAGS} -L/opt/homebrew/lib"
+	fi
 	# Use fink packages if available.
 	#if test -d /sw/include && test -d /sw/lib; then
 	#    CPPFLAGS="${CPPFLAGS} -I/sw/include"

--- a/lib/lame/quantize.c
+++ b/lib/lame/quantize.c
@@ -1279,7 +1279,7 @@ VBR_prepare (
 }
  
  
-inline
+//inline
 void bitpressure_strategy1(
     lame_internal_flags * gfc,
     III_psy_xmin l3_xmin[2][2],
@@ -1305,7 +1305,7 @@ void bitpressure_strategy1(
     }
 }
 
-inline
+//inline
 void bitpressure_strategy2( 
     lame_internal_flags * gfc,
     int bpf, int used, int save_bits[2][2],

--- a/src/gfx2gfx.c
+++ b/src/gfx2gfx.c
@@ -24,27 +24,27 @@
 #include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
-#include "../../swftools/config.h"
-#include "../../swftools/lib/args.h"
-#include "../../swftools/lib/os.h"
-#include "../../swftools/lib/gfxsource.h"
-#include "../../swftools/lib/gfxdevice.h"
-#include "../../swftools/lib/gfxpoly.h"
-#include "../../swftools/lib/devices/pdf.h"
-#include "../../swftools/lib/devices/swf.h"
-#include "../../swftools/lib/devices/text.h"
-#include "../../swftools/lib/devices/render.h"
-#include "../../swftools/lib/devices/file.h"
-#include "../../swftools/lib/devices/bbox.h"
+#include "../config.h"
+#include "../lib/args.h"
+#include "../lib/os.h"
+#include "../lib/gfxsource.h"
+#include "../lib/gfxdevice.h"
+#include "../lib/gfxpoly.h"
+#include "../lib/devices/pdf.h"
+#include "../lib/devices/swf.h"
+#include "../lib/devices/text.h"
+#include "../lib/devices/render.h"
+#include "../lib/devices/file.h"
+#include "../lib/devices/bbox.h"
 #ifdef HAVE_LRF
-#include "../../swftools/lib/devices/lrf.h"
+#include "../lib/devices/lrf.h"
 #endif
-#include "../../swftools/lib/devices/rescale.h"
-#include "../../swftools/lib/devices/record.h"
-#include "../../swftools/lib/readers/image.h"
-#include "../../swftools/lib/readers/swf.h"
-#include "../../swftools/lib/pdf/pdf.h"
-#include "../../swftools/lib/log.h"
+#include "../lib/devices/rescale.h"
+#include "../lib/devices/record.h"
+#include "../lib/readers/image.h"
+#include "../lib/readers/swf.h"
+#include "../lib/pdf/pdf.h"
+#include "../lib/log.h"
 
 static gfxsource_t*driver = 0;
 


### PR DESCRIPTION
- On Apple Silicon, homebrew installs packages to /opt/homebrew/ rather than /usr/local/ which the current configure script doesn't detect.
  - This is fixed by https://github.com/flanter21/swftools/commit/d0e9ff6f53aad5990b365b0632e6bdc0c33dd703.
- The use of the `inline` directive in lib/lame/quantize.c has been known to cause problems before. See https://github.com/matthiaskramm/swftools/issues/178 and https://github.com/matthiaskramm/swftools/pull/179.
  - This is fixed by https://github.com/flanter21/swftools/commit/bd22ccad6d020779bf60f7a8f8aeda7f7177f7d7
  - The issue described above applies to both `bitpressure_strategy1` and `bitpressure_strategy2` on arm64 linux so I have commented out both inline directives where the issue would occur, rather than just the first like in the issues above.
- The `#include`s gfx2gfx.c uses go up two folders rather than just one. I didn't notice any issue in changing it to just go up one folder.
  - https://github.com/flanter21/swftools/commit/1f2e2de76e31fcb8c9e79f807b81aadc00dfe207 fixes an issue that occurred if you attempted to compile gfx2gfx when the repo is in a folder that is not called "swftools".
- One issue remains that none of these utilities will compile on arm64 linux unless you update [config.sub](https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD) and [config.guess](https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD).
  - I have not included these in my pull request since I am unsure as to whether it is a license violation to include the now GPLv3-or-later files in a project that is GPLv2-or-later.
  - To fix this on their system, the user can regenerate the config files and script by running
      ```
      autoreconf --install --force --include=m4
      autoupdate
      autoconf
      ```
      and then just compile as normal.

Edit: had broken this pull request, but now it has been fixed